### PR TITLE
Made modification on execution command by changing `ncov-ucas` to current repo name `ucas-covid19`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 4. （可选）填写[server酱](http://sc.ftqq.com/3.version)的api，填写之后可以在程序完成打卡之后通知到微信，如果不填写不影响使用
 5. 上传`sub.py`到自己的服务器上，修改crontab，设定为每天八点半运行，注意需要修改以下命令的路径为实际路径。
 ```
-30 8 * * * /usr/bin/python3  /root/ncov-ucas/sub.py >>/tmp/yqfk.log
+30 8 * * * /usr/bin/python3  /root/ucas-covid19/sub.py >>/tmp/yqfk.log
 ```
 
 


### PR DESCRIPTION
This modification is made based on 2 facts:

1. The default `crontab` command given by the repo is not ready to be directly used, where users still have to change original `ncov-ucas` to `ucas-covid19` even if the repo is put under default `/root/` directory.
2. `2019-nCov` is considered as the name for the virus rather than the disease. In my humble opinion, such modification is semantically more reasonable.